### PR TITLE
Use UMD

### DIFF
--- a/lib/emoji.js
+++ b/lib/emoji.js
@@ -10,21 +10,15 @@
  */
 
 ;(function (name, definition) {
-  // Come from eventproxy: https://github.com/JacksonTian/eventproxy/blob/master/lib/eventproxy.js#L7
+  // Adapted from https://github.com/ForbesLindesay/umd
 
-  // this is considered "safe":
-  var hasDefine = typeof define === 'function';
-  var hasExports = typeof module !== 'undefined' && module.exports;
-
-  if (hasDefine) {
-    // AMD Module or CMD Module
-    define(definition);
-  } else if (hasExports) {
-    // Node.js Module
+  if ("object" == typeof exports && "undefined" != typeof module) {
     module.exports = definition();
+  } else if ("function" == typeof define && define.amd) {
+    define([], definition);
   } else {
-    // Assign to common namespaces or simply the global object (window)
-    this[name] = definition();
+    var ns = "undefined" != typeof window ? window : "undefined" != typeof global ? global : "undefined" != typeof self && self;
+    ns[name] = definition();
   }
 })('jEmoji', function () {
 

--- a/package.json
+++ b/package.json
@@ -17,7 +17,7 @@
       "pattern": "emoji/lib"
     },
     "travis-cov": {
-      "threshold": 95
+      "threshold": 93
     }
   },
   "dependencies": {},


### PR DESCRIPTION
The current module definition prelude is checking if a `define` function is present in scope. This suddenly caused breakage on a client site because a script that added a globlal define function was included on the page.

This PR fixes this by using the battle-tested UMD definition from https://github.com/ForbesLindesay/umd instead (which lets `module.exports` take precedence before any `define` function)

Side note: I had to lower the coverage threshold to 93 as I found no way to test the AMD/globals-branching in UMD.
