### PR TITLE
Added in support for conversion from unified to a JSON object

### DIFF
--- a/lib/emoji.js
+++ b/lib/emoji.js
@@ -950,11 +950,12 @@ jEmoji.unifiedToHTML = unifiedToHTML;
 function unifiedToJSON(text) {
   // create an array to store the objects in
   var json = [];
-  text.replace(jEmoji.EMOJI_RE(), function (_, m) {
+  text.replace(jEmoji.EMOJI_RE(), function (_, m, offset) {
     var em = EMOJI_MAP[m];
     json.push({
       code: em[2],
-      title: em[1]
+      title: em[1],
+      offset: offset
     });
   });
   return json;

--- a/lib/emoji.js
+++ b/lib/emoji.js
@@ -941,6 +941,28 @@ function unifiedToHTML(text) {
 }
 jEmoji.unifiedToHTML = unifiedToHTML;
 
+/**
+ * Convert unified code to a JSON object containing their code and title.
+ *
+ * @param {String} text
+ * @return {Object} a JSON object with code/title.
+ */
+function unifiedToJSON(text) {
+  // create an array to store the objects in
+  var json = [];
+  text.replace(jEmoji.EMOJI_RE(), function (_, m) {
+    var em = EMOJI_MAP[m];
+    console.log(em[2]);
+    console.log(em[1]);
+    json.push({
+      code: em[2],
+      title: em[1]
+    });
+  });
+  return json;
+}
+jEmoji.unifiedToJSON = unifiedToJSON;
+
 var EMOJI_DOCOMO_MAP = {};
 var EMOJI_KDDI_MAP = {};
 var EMOJI_SOFTBANK_MAP = {};

--- a/lib/emoji.js
+++ b/lib/emoji.js
@@ -952,8 +952,6 @@ function unifiedToJSON(text) {
   var json = [];
   text.replace(jEmoji.EMOJI_RE(), function (_, m) {
     var em = EMOJI_MAP[m];
-    console.log(em[2]);
-    console.log(em[1]);
     json.push({
       code: em[2],
       title: em[1]


### PR DESCRIPTION
Convert unified emoji to a JSON object containing the code and the
emoji title.

e.g.: 
- passing 🛂 to unifiedToJSON returns 

```
[
  { 
    code: '1f6c2',
    title: 'passport control' 
  } 
]
```
- passing 🛂😀 to unifiedToJSON returns  

```
[ 
  { 
    code: '1f6c2',
    title: 'passport control'
  },
  {
    code: '1f600',
    title: 'grinning face' 
  } 
]
```
